### PR TITLE
Fix ProtocolError when connecting to PyPy using http

### DIFF
--- a/caniusepypy/pypi.py
+++ b/caniusepypy/pypi.py
@@ -46,7 +46,7 @@ def just_name(supposed_name):
 
 @contextlib.contextmanager
 def pypi_client():
-    client = xmlrpc_client.ServerProxy('http://pypi.python.org/pypi')
+    client = xmlrpc_client.ServerProxy('https://pypi.python.org/pypi')
     try:
         yield client
     finally:


### PR DESCRIPTION
The following PR solves the problem given when executing `caniusepypy` command.
- Changed `http` to use `https` instead when connecting with `pypi.python.org/pypi`
